### PR TITLE
Add flatten-array

### DIFF
--- a/config.json
+++ b/config.json
@@ -53,6 +53,14 @@
         "status": "beta"
       },
       {
+        "slug": "flatten-array",
+        "name": "Flatten List",
+        "uuid": "23b5a864-186c-4a4d-ba32-83608b0d18f6",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
         "slug": "triangle",
         "name": "Triangle",
         "uuid": "aab55f24-e31a-4e99-8c6c-12e69de7ce7c",

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "active": false,
   "status": {
     "concept_exercises": false,
-    "test_runner": false,
+    "test_runner": true,
     "representer": false,
     "analyzer": false
   },
@@ -13,7 +13,10 @@
   "online_editor": {
     "indent_style": "space",
     "indent_size": 2,
-    "highlightjs_language": "TODO: specify highlightjs language"
+    "highlightjs_language": "plaintext"
+  },
+  "test_runner": {
+    "average_run_time": 3
   },
   "files": {
     "solution": [
@@ -36,6 +39,118 @@
     "concept": [],
     "practice": [
       {
+        "slug": "acronym",
+        "name": "Acronym",
+        "uuid": "5ae47f42-45fc-4de2-b0df-3098ef622b0c",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
+        "slug": "anagram",
+        "name": "Anagram",
+        "uuid": "52e3290f-b78f-423f-a1cf-d727edc9fa73",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
+        "slug": "armstrong-numbers",
+        "name": "Armstrong Numbers",
+        "uuid": "26431238-01d5-4890-9bb1-f5b023e2c295",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
+        "slug": "atbash-cipher",
+        "name": "Atbash Cipher",
+        "uuid": "7263c877-5ddd-4c48-886f-e3f57967f649",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
+        "slug": "binary-search",
+        "name": "Binary Search",
+        "uuid": "dc4437e4-9ab3-4ab0-ae0d-ae3d2287e97c",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
+        "slug": "bob",
+        "name": "Bob",
+        "uuid": "28d1beed-ff83-4341-8a71-08fd287489fd",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
+        "slug": "collatz-conjecture",
+        "name": "Collatz Conjecture",
+        "uuid": "00a0a185-0b05-4f83-a840-80070635255a",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
+        "slug": "darts",
+        "name": "Darts",
+        "uuid": "d70a98f9-4743-40b7-ab18-f37d5508a7a5",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
+      },
+      {
+        "slug": "difference-of-squares",
+        "name": "Difference of Squares",
+        "uuid": "6968b216-4478-4778-93d3-197ed849fd40",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
+        "slug": "dnd-character",
+        "name": "D&D Character",
+        "uuid": "2401de1d-0a63-49b2-ad22-3807cd76778f",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5
+      },
+      {
+        "slug": "etl",
+        "name": "ETL",
+        "uuid": "a86c1654-da80-46c9-aba5-a2eec3f66262",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
+        "slug": "flatten-array",
+        "name": "Flatten List",
+        "uuid": "23b5a864-186c-4a4d-ba32-83608b0d18f6",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
+        "slug": "grains",
+        "name": "Grains",
+        "uuid": "04948c47-34d1-4200-a6f0-5131f63c5600",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
+        "slug": "hamming",
+        "name": "Hamming",
+        "uuid": "731dcc09-a78c-4da4-a6c7-47bb0b6720f2",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
         "slug": "hello-world",
         "name": "Ahoy World",
         "uuid": "21cb7132-eb7a-41cc-b100-4655288c3c98",
@@ -49,70 +164,7 @@
         "uuid": "dff46c06-d8be-48e0-8158-4c6c484a3cbc",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 3,
-        "status": "beta"
-      },
-      {
-        "slug": "flatten-array",
-        "name": "Flatten List",
-        "uuid": "23b5a864-186c-4a4d-ba32-83608b0d18f6",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2
-      },
-      {
-        "slug": "triangle",
-        "name": "Triangle",
-        "uuid": "aab55f24-e31a-4e99-8c6c-12e69de7ce7c",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "status": "beta"
-      },
-      {
-        "slug": "resistor-color",
-        "name": "Resistor Color",
-        "uuid": "57bc4302-4c4b-43a7-9abb-2378dd6ef70e",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "status": "beta"
-      },
-      {
-        "slug": "etl",
-        "name": "ETL",
-        "uuid": "a86c1654-da80-46c9-aba5-a2eec3f66262",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "status": "beta"
-      },
-      {
-        "slug": "binary-search",
-        "name": "Binary Search",
-        "uuid": "dc4437e4-9ab3-4ab0-ae0d-ae3d2287e97c",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "status": "beta"
-      },
-      {
-        "slug": "nucleotide-count",
-        "name": "Nucleotide Count",
-        "uuid": "437768f4-a4d4-4a87-bf8b-6fe403e34179",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "status": "beta"
-      },
-      {
-        "slug": "difference-of-squares",
-        "name": "Difference of Squares",
-        "uuid": "6968b216-4478-4778-93d3-197ed849fd40",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "status": "beta"
+        "difficulty": 3
       },
       {
         "slug": "leap",
@@ -120,119 +172,12 @@
         "uuid": "c67175ca-9706-4aec-a45b-040a23ef25c7",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 3,
-        "status": "beta"
+        "difficulty": 3
       },
       {
-        "slug": "two-fer",
-        "name": "Two Fer",
-        "uuid": "198c1176-536a-49db-828b-0dc1655d7da9",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1
-      },
-      {
-        "slug": "space-age",
-        "name": "Space Age",
-        "uuid": "fcdf45a2-a72c-4983-8271-ca9276467f98",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "status": "beta"
-      },
-      {
-        "slug": "atbash-cipher",
-        "name": "Atbash Cipher",
-        "uuid": "7263c877-5ddd-4c48-886f-e3f57967f649",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "status": "beta"
-      },
-      {
-        "slug": "collatz-conjecture",
-        "name": "Collatz Conjecture",
-        "uuid": "00a0a185-0b05-4f83-a840-80070635255a",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "status": "beta"
-      },
-      {
-        "slug": "reverse-string",
-        "name": "Reverse String",
-        "uuid": "69911771-a41a-4be9-b685-678def75e1b2",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2
-      },
-      {
-        "slug": "raindrops",
-        "name": "Raindrops",
-        "uuid": "8dcd513e-93f5-499b-a388-0a7f3c7898dd",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "status": "beta"
-      },
-      {
-        "slug": "resistor-color-duo",
-        "name": "Resistor Color Duo",
-        "uuid": "3f897d66-6f49-49ca-a6ab-a168d6ef5e68",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "status": "beta"
-      },
-      {
-        "slug": "series",
-        "name": "Series",
-        "uuid": "f58b5305-3bf2-4c15-8aac-339a97204d06",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "status": "beta"
-      },
-      {
-        "slug": "secret-handshake",
-        "name": "Secret Handshake",
-        "uuid": "3a830edd-253c-4889-ad6b-9402fea4af97",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "status": "beta"
-      },
-      {
-        "slug": "bob",
-        "name": "Bob",
-        "uuid": "28d1beed-ff83-4341-8a71-08fd287489fd",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "status": "beta"
-      },
-      {
-        "slug": "protein-translation",
-        "name": "Protein Translation",
-        "uuid": "29563d5a-a703-43c8-953e-3fde7daae3b0",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "topics": null
-      },
-      {
-        "slug": "anagram",
-        "name": "Anagram",
-        "uuid": "52e3290f-b78f-423f-a1cf-d727edc9fa73",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "status": "beta"
-      },
-      {
-        "slug": "grains",
-        "name": "Grains",
-        "uuid": "04948c47-34d1-4200-a6f0-5131f63c5600",
+        "slug": "luhn",
+        "name": "Luhn",
+        "uuid": "9476a1c3-1775-453d-bb08-be919fd03bad",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3
@@ -243,26 +188,127 @@
         "uuid": "eef61f56-6dda-4389-b348-7c27835493b8",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 3,
-        "status": "beta"
+        "difficulty": 3
       },
       {
-        "slug": "dnd-character",
-        "name": "D&D Character",
-        "uuid": "2401de1d-0a63-49b2-ad22-3807cd76778f",
+        "slug": "nucleotide-count",
+        "name": "Nucleotide Count",
+        "uuid": "437768f4-a4d4-4a87-bf8b-6fe403e34179",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 5,
-        "status": "beta"
+        "difficulty": 3
       },
       {
-        "slug": "darts",
-        "name": "Darts",
-        "uuid": "d70a98f9-4743-40b7-ab18-f37d5508a7a5",
+        "slug": "pangram",
+        "name": "Pangram",
+        "uuid": "ef2dc89f-a9d2-48f0-9bb5-4cafeb50c81c",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1,
-        "status": "beta"
+        "difficulty": 3
+      },
+      {
+        "slug": "protein-translation",
+        "name": "Protein Translation",
+        "uuid": "29563d5a-a703-43c8-953e-3fde7daae3b0",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
+        "slug": "raindrops",
+        "name": "Raindrops",
+        "uuid": "8dcd513e-93f5-499b-a388-0a7f3c7898dd",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
+        "slug": "resistor-color",
+        "name": "Resistor Color",
+        "uuid": "57bc4302-4c4b-43a7-9abb-2378dd6ef70e",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
+        "slug": "resistor-color-duo",
+        "name": "Resistor Color Duo",
+        "uuid": "3f897d66-6f49-49ca-a6ab-a168d6ef5e68",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
+        "slug": "resistor-color-trio",
+        "name": "Resistor Color Trio",
+        "uuid": "4e758c9f-3204-41cd-b8d1-8f978bd90809",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
+        "slug": "reverse-string",
+        "name": "Reverse String",
+        "uuid": "69911771-a41a-4be9-b685-678def75e1b2",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
+      },
+      {
+        "slug": "scrabble-score",
+        "name": "Scrabble Score",
+        "uuid": "8b1cfd2f-0d25-4eec-9b8e-75c7a339fc6c",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
+        "slug": "secret-handshake",
+        "name": "Secret Handshake",
+        "uuid": "3a830edd-253c-4889-ad6b-9402fea4af97",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
+        "slug": "series",
+        "name": "Series",
+        "uuid": "f58b5305-3bf2-4c15-8aac-339a97204d06",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
+        "slug": "space-age",
+        "name": "Space Age",
+        "uuid": "fcdf45a2-a72c-4983-8271-ca9276467f98",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
+        "slug": "triangle",
+        "name": "Triangle",
+        "uuid": "aab55f24-e31a-4e99-8c6c-12e69de7ce7c",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
+        "slug": "square-root",
+        "name": "Square Root",
+        "uuid": "351651f4-3e42-4392-8862-9a18f9acb70d",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
+        "slug": "two-fer",
+        "name": "Two Fer",
+        "uuid": "198c1176-536a-49db-828b-0dc1655d7da9",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/flatten-array/.docs/instructions-append.md
+++ b/exercises/practice/flatten-array/.docs/instructions-append.md
@@ -1,0 +1,5 @@
+# Instructions append
+
+This exercise is implemented using the built-in [List] datatype, not RawArrays.
+
+[list]: https://pyret.org/docs/latest/lists.html

--- a/exercises/practice/flatten-array/.docs/instructions.md
+++ b/exercises/practice/flatten-array/.docs/instructions.md
@@ -1,0 +1,11 @@
+# Instructions
+
+Take a nested list and return a single flattened list with all values except nil/null.
+
+The challenge is to write a function that accepts an arbitrarily-deep nested list-like structure and returns a flattened structure without any nil/null values.
+
+For example:
+
+input: [1,[2,3,null,4],[null],5]
+
+output: [1,2,3,4,5]

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "BNAndras"
+  ],
+  "files": {
+    "solution": [
+      "flatten-array.arr"
+    ],
+    "test": [
+      "flatten-array-test.arr"
+    ],
+    "example": [
+      ".meta/example.arr"
+    ]
+  },
+  "blurb": "Take a nested list and return a single list with all values except nil/null.",
+  "source": "Interview Question",
+  "source_url": "https://reference.wolfram.com/language/ref/Flatten.html"
+}

--- a/exercises/practice/flatten-array/.meta/example.arr
+++ b/exercises/practice/flatten-array/.meta/example.arr
@@ -1,0 +1,20 @@
+provide: flatten end
+
+import lists as L
+
+fun flatten(lst):
+  lst.foldr(lam(elt, acc):
+      ask:
+        | elt == nothing then:
+          acc
+        | is-empty(elt) then:
+          acc
+        | is-link(elt) then:
+          result = flatten(elt)
+          result.append(acc)
+        | otherwise:
+          L.push(acc, elt)
+      end
+    end,
+    [list: ])
+end

--- a/exercises/practice/flatten-array/.meta/example.arr
+++ b/exercises/practice/flatten-array/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 provide: flatten end
 
 import lists as L

--- a/exercises/practice/flatten-array/.meta/tests.toml
+++ b/exercises/practice/flatten-array/.meta/tests.toml
@@ -1,0 +1,43 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[8c71dabd-da60-422d-a290-4a571471fb14]
+description = "empty"
+
+[d268b919-963c-442d-9f07-82b93f1b518c]
+description = "no nesting"
+
+[3f15bede-c856-479e-bb71-1684b20c6a30]
+description = "flattens a nested array"
+
+[c84440cc-bb3a-48a6-862c-94cf23f2815d]
+description = "flattens array with just integers present"
+
+[d3d99d39-6be5-44f5-a31d-6037d92ba34f]
+description = "5 level nesting"
+
+[d572bdba-c127-43ed-bdcd-6222ac83d9f7]
+description = "6 level nesting"
+
+[0705a8e5-dc86-4cec-8909-150c5e54fa9c]
+description = "null values are omitted from the final result"
+
+[c6cf26de-8ccd-4410-84bd-b9efd88fd2bc]
+description = "consecutive null values at the front of the list are omitted from the final result"
+
+[382c5242-587e-4577-b8ce-a5fb51e385a1]
+description = "consecutive null values in the middle of the list are omitted from the final result"
+
+[ef1d4790-1b1e-4939-a179-51ace0829dbd]
+description = "6 level nest list with null values"
+
+[85721643-705a-4150-93ab-7ae398e2942d]
+description = "all values in nested list are null"

--- a/exercises/practice/flatten-array/flatten-array-test.arr
+++ b/exercises/practice/flatten-array/flatten-array-test.arr
@@ -1,155 +1,207 @@
+use context essentials2020
+
 include file("flatten-array.arr")
 
-check "empty":
-  input = [list: ]
+#|
+  When working offline, all tests except the first one are skipped by default.
+  Once you get the first test running, unskip the next one until all tests pass locally.
+  Check the block comment below for further details.
+|#
 
-  expected = [list: ]
+fun empty-list():
+  check "empty":
+    input = [list: ]
 
-  flatten(input) is expected
+    expected = [list: ]
+
+    flatten(input) is expected
+  end
 end
 
-check "no nesting":
-  input = [list: 0, 1, 2]
+fun no-nesting():
+  check "no nesting":
+    input = [list: 0, 1, 2]
 
-  expected = [list: 0, 1, 2]
+    expected = [list: 0, 1, 2]
 
-  flatten(input) is expected
+    flatten(input) is expected
+  end
 end
 
-check "flattens a nested array":
-  input = [list: [list: ]]
+fun nested-list():
+  check "flattens a nested list":
+    input = [list: [list: ]]
 
-  expected = [list: ]
+    expected = [list: ]
 
-  flatten(input) is expected
+    flatten(input) is expected
+  end
 end
 
-check "flattens array with just integers present":
-  input = [list: 1, [list: 2, 3, 4, 5, 6, 7], 8]
+fun numeric-list():
+  check "flattens list with just integers present":
+    input = [list: 1, [list: 2, 3, 4, 5, 6, 7], 8]
 
-  expected = [list: 1, 2, 3, 4, 5, 6, 7, 8]
+    expected = [list: 1, 2, 3, 4, 5, 6, 7, 8]
 
-  flatten(input) is expected
+    flatten(input) is expected
+  end
 end
 
-check "5 level nesting":
-  input = [list:
-    0,
-    2,
-    [list:
-      [list: 2, 3],
+fun five-levels():
+  check "5 level nesting":
+    input = [list:
+      0,
+      2,
+      [list:
+        [list: 2, 3],
+        8,
+        100,
+        4,
+        [list:
+          [list:
+            [list: 50]]]],
+      -2]
+
+    expected = [list:
+      0,
+      2,
+      2,
+      3,
       8,
       100,
       4,
+      50,
+      -2]
+
+    flatten(input) is expected
+  end
+end
+
+fun six-levels():
+  check "6 level nesting":
+    input = [list:
+      1,
+      [list:
+        2,
+        [list: [list: 3]],
+        [list:
+        4,
+        [list: [list: 5]]],
+        6,
+        7],
+      8]
+
+    expected = [list:
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8]
+
+    flatten(input) is expected
+  end
+end
+
+fun omit-a-nothing():
+  check "nothing values are omitted from the final result":
+    input = [list: 1, 2, nothing]
+
+    expected = [list: 1, 2]
+
+    flatten(input) is expected
+  end
+end
+
+fun omit-nothings-from-beginning():
+  check "consecutive nothing values at the front of the list are omitted from the final result":
+    input = [list: nothing, nothing, 3]
+
+    expected = [list: 3]
+
+    flatten(input) is expected
+  end
+end
+
+fun omit-nothings-from-middle():
+  check "consecutive nothing values in the middle of the list are omitted from the final result":
+    input = [list: 1, nothing, nothing, 4]
+
+    expected = [list: 1, 4]
+
+    flatten(input) is expected
+  end
+end
+
+fun six-levels-with-nothings():
+  check "6 level nest list with nothing values":
+    input = [list:
+      0,
+      2,
+      [list:
+        [list: 2, 3],
+        8,
+        [list: [list: 100 ]],
+        nothing,
+        [list: [list: nothing]]],
+      -2]
+
+    expected = [list:
+      0,
+      2,
+      2,
+      3,
+      8,
+      100,
+      -2]
+
+    flatten(input) is expected
+  end
+end
+
+fun all-nothings():
+  check "all values in nested list are nothing":
+    input = [list:
+      nothing,
       [list:
         [list:
-          [list: 50]]]],
-    -2]
-
-  expected = [list:
-    0,
-    2,
-    2,
-    3,
-    8,
-    100,
-    4,
-    50,
-    -2]
-
-  flatten(input) is expected
-end
-
-check "6 level nesting":
-  input = [list:
-    1,
-    [list:
-      2,
-      [list: [list: 3]],
-      [list:
-      4,
-      [list: [list: 5]]],
-      6,
-      7],
-    8]
-
-  expected = [list:
-    1,
-    2,
-    3,
-    4,
-    5,
-    6,
-    7,
-    8]
-
-  flatten(input) is expected
-end
-
-check "null values are omitted from the final result":
-  input = [list: 1, 2, nothing]
-
-  expected = [list: 1, 2]
-
-  flatten(input) is expected
-end
-
-check "consecutive null values at the front of the list are omitted from the final result":
-  input = [list: nothing, nothing, 3]
-
-  expected = [list: 3]
-
-  flatten(input) is expected
-end
-
-check "consecutive null values in the middle of the list are omitted from the final result":
-  input = [list: 1, nothing, nothing, 4]
-
-  expected = [list: 1, 4]
-
-  flatten(input) is expected
-end
-
-check "6 level nest list with null values":
-  input = [list:
-    0,
-    2,
-    [list:
-      [list: 2, 3],
-      8,
-      [list: [list: 100 ]],
+          [list: nothing]]],
       nothing,
-      [list: [list: nothing]]],
-    -2]
-
-  expected = [list:
-    0,
-    2,
-    2,
-    3,
-    8,
-    100,
-    -2]
-
-  flatten(input) is expected
-end
-
-check "all values in nested list are null":
-  input = [list:
-    nothing,
-    [list:
+      nothing,
       [list:
-        [list: nothing]]],
-    nothing,
-    nothing,
-    [list:
-      [list:
-        nothing,
+        [list:
+          nothing,
+          nothing],
         nothing],
-      nothing],
-    nothing]
+      nothing]
 
-  expected = [list: ]
+    expected = [list: ]
 
-  flatten(input) is expected
+    flatten(input) is expected
+  end
 end
+
+#|
+  Code to run each test. Each line corresponds to a test above and whether it should be run.
+  To mark a test to be run, replace `false` with `true` on that same line after the comma.
+  test(test-a, true) will be run. test(test-a, false) will be skipped.
+|#
+
+data TestRun: test(run, active) end
+
+[list: 
+  test(empty-list, true),
+  test(no-nesting, false),
+  test(nested-list, false),
+  test(numeric-list, false),
+  test(five-levels, false),
+  test(six-levels, false),
+  test(omit-a-nothing, false),
+  test(omit-nothings-from-beginning, false),
+  test(omit-nothings-from-middle, false),
+  test(six-levels-with-nothings, false),
+  test(all-nothings, false)
+].each(lam(t): when t.active: t.run() end end)

--- a/exercises/practice/flatten-array/flatten-array-test.arr
+++ b/exercises/practice/flatten-array/flatten-array-test.arr
@@ -1,0 +1,155 @@
+include file("flatten-array.arr")
+
+check "empty":
+  input = [list: ]
+
+  expected = [list: ]
+
+  flatten(input) is expected
+end
+
+check "no nesting":
+  input = [list: 0, 1, 2]
+
+  expected = [list: 0, 1, 2]
+
+  flatten(input) is expected
+end
+
+check "flattens a nested array":
+  input = [list: [list: ]]
+
+  expected = [list: ]
+
+  flatten(input) is expected
+end
+
+check "flattens array with just integers present":
+  input = [list: 1, [list: 2, 3, 4, 5, 6, 7], 8]
+
+  expected = [list: 1, 2, 3, 4, 5, 6, 7, 8]
+
+  flatten(input) is expected
+end
+
+check "5 level nesting":
+  input = [list:
+    0,
+    2,
+    [list:
+      [list: 2, 3],
+      8,
+      100,
+      4,
+      [list:
+        [list:
+          [list: 50]]]],
+    -2]
+
+  expected = [list:
+    0,
+    2,
+    2,
+    3,
+    8,
+    100,
+    4,
+    50,
+    -2]
+
+  flatten(input) is expected
+end
+
+check "6 level nesting":
+  input = [list:
+    1,
+    [list:
+      2,
+      [list: [list: 3]],
+      [list:
+      4,
+      [list: [list: 5]]],
+      6,
+      7],
+    8]
+
+  expected = [list:
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8]
+
+  flatten(input) is expected
+end
+
+check "null values are omitted from the final result":
+  input = [list: 1, 2, nothing]
+
+  expected = [list: 1, 2]
+
+  flatten(input) is expected
+end
+
+check "consecutive null values at the front of the list are omitted from the final result":
+  input = [list: nothing, nothing, 3]
+
+  expected = [list: 3]
+
+  flatten(input) is expected
+end
+
+check "consecutive null values in the middle of the list are omitted from the final result":
+  input = [list: 1, nothing, nothing, 4]
+
+  expected = [list: 1, 4]
+
+  flatten(input) is expected
+end
+
+check "6 level nest list with null values":
+  input = [list:
+    0,
+    2,
+    [list:
+      [list: 2, 3],
+      8,
+      [list: [list: 100 ]],
+      nothing,
+      [list: [list: nothing]]],
+    -2]
+
+  expected = [list:
+    0,
+    2,
+    2,
+    3,
+    8,
+    100,
+    -2]
+
+  flatten(input) is expected
+end
+
+check "all values in nested list are null":
+  input = [list:
+    nothing,
+    [list:
+      [list:
+        [list: nothing]]],
+    nothing,
+    nothing,
+    [list:
+      [list:
+        nothing,
+        nothing],
+      nothing],
+    nothing]
+
+  expected = [list: ]
+
+  flatten(input) is expected
+end

--- a/exercises/practice/flatten-array/flatten-array.arr
+++ b/exercises/practice/flatten-array/flatten-array.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 provide: flatten end
 
 fun flatten(lst):

--- a/exercises/practice/flatten-array/flatten-array.arr
+++ b/exercises/practice/flatten-array/flatten-array.arr
@@ -1,5 +1,5 @@
 provide: flatten end
 
 fun flatten(lst):
-  raise("please implement the flatten list")
+  raise("please implement the flatten function")
 end

--- a/exercises/practice/flatten-array/flatten-array.arr
+++ b/exercises/practice/flatten-array/flatten-array.arr
@@ -1,0 +1,5 @@
+provide: flatten end
+
+fun flatten(lst):
+  raise("please implement the flatten list")
+end


### PR DESCRIPTION
@BethanyG, this is another one for your review, but it's not a priority since we have enough exercises for launch.

I set this up using lists for simplicity, but I'm thinking the exercise could benefit from having the students deal with mutable [arrays][https://pyret.org/docs/latest/arrays.html] instead. We don't have any exercises yet that lend themselves to an array since lists are more versatile. If we swap to arrays, a student can still use lists internally as long as they convert the list back to an array at the end. If they use arrays, they'd likely need a [for loop[https://pyret.org/docs/latest/A_Tour_of_Pyret.html#%28part._.For_loops%29] which might bump up the difficulty. Either way, we'll want an instructions append to clarify to students what we're expecting since the instructions reference lists in an exercise whose name references arrays.