### PR TITLE
Fix precision testing

### DIFF
--- a/exercises/practice/space-age/.meta/example.arr
+++ b/exercises/practice/space-age/.meta/example.arr
@@ -19,7 +19,6 @@ fun on-planet(planet, seconds):
   cases(Option) ORBITAL-RATIOS.get(planet):
     | none => raise("not a planet")
     | some(ratio) => 
-        value = ((seconds / EARTH-SECONDS) / ratio)
-        num-round(value * 100) / 100
+        (seconds / EARTH-SECONDS) / ratio
   end
 end

--- a/exercises/practice/space-age/space-age-test.arr
+++ b/exercises/practice/space-age/space-age-test.arr
@@ -1,37 +1,43 @@
 include file("space-age.arr")
 
+fun around(delta):
+  lam(actual, target):
+    num-abs(target - actual) <= delta
+  end
+end
+
 check "age on Earth":
-    on-planet("Earth", 1000000000) is 31.69
+  on-planet("Earth", 1000000000)  is%(around(0.01)) 31.69
 end
 
 check "age on Mercury":
-    on-planet("Mercury", 2134835688) is 280.88
+  on-planet("Mercury", 2134835688) is%(around(0.01)) 280.88
 end
 
 check "age on Venus":
-    on-planet("Venus", 189839836) is 9.78
+  on-planet("Venus", 189839836) is%(around(0.01)) 9.78
 end
 
 check "age on Mars":
-    on-planet("Mars", 2129871239) is 35.88
+  on-planet("Mars", 2129871239) is%(around(0.01)) 35.88
 end
 
 check "age on Jupiter":
-    on-planet("Jupiter", 901876382) is 2.41
+  on-planet("Jupiter", 901876382) is%(around(0.01)) 2.41
 end
 
 check "age on Saturn":
-    on-planet("Saturn", 2000000000) is 2.15
+  on-planet("Saturn", 2000000000) is%(around(0.01)) 2.15
 end
 
 check "age on Uranus":
-    on-planet("Uranus", 1210123456) is 0.46
+  on-planet("Uranus", 1210123456) is%(around(0.01)) 0.46
 end
 
 check "age on Neptune":
-    on-planet("Neptune", 1821023456) is 0.35
+  on-planet("Neptune", 1821023456) is%(around(0.01)) 0.35
 end
 
 check "invalid planet causes error":
-    on-planet("Sun", 680804807) raises "not a planet"
+  on-planet("Sun", 680804807) raises "not a planet"
 end


### PR DESCRIPTION
This way, students aren't forced to round to two digits in their solution (see [https://forum.exercism.org/t/space-age-why-are-the-tests-expecting-rounded-values/6645](https://forum.exercism.org/t/space-age-why-are-the-tests-expecting-rounded-values/6645))