### PR TITLE
Add simple-linked-list

### DIFF
--- a/config.json
+++ b/config.json
@@ -303,6 +303,14 @@
         "difficulty": 3
       },
       {
+        "slug": "simple-linked-list",
+        "name": "Simple Linked List",
+        "uuid": "c2529f83-00db-427c-a478-57a8c7512f12",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
         "slug": "space-age",
         "name": "Space Age",
         "uuid": "fcdf45a2-a72c-4983-8271-ca9276467f98",

--- a/exercises/practice/simple-linked-list/.docs/instructions.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.md
@@ -1,0 +1,19 @@
+# Instructions
+
+Write a prototype of the music player application.
+
+For the prototype, each song will simply be represented by a number.
+Given a range of numbers (the song IDs), create a singly linked list.
+
+Given a singly linked list, you should be able to reverse the list to play the songs in the opposite order.
+
+~~~~exercism/note
+The linked list is a fundamental data structure in computer science, often used in the implementation of other data structures.
+
+The simplest kind of linked list is a **singly** linked list.
+That means that each element (or "node") contains data, along with something that points to the next node in the list.
+
+If you want to dig deeper into linked lists, check out [this article][intro-linked-list] that explains it using nice drawings.
+
+[intro-linked-list]: https://medium.com/basecs/whats-a-linked-list-anyway-part-1-d8b7e6508b9d
+~~~~

--- a/exercises/practice/simple-linked-list/.docs/introduction.md
+++ b/exercises/practice/simple-linked-list/.docs/introduction.md
@@ -1,0 +1,5 @@
+# Introduction
+
+You work for a music streaming company.
+
+You've been tasked with creating a playlist feature for your music player application.

--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "BNAndras"
+  ],
+  "files": {
+    "solution": [
+      "simple-linked-list.arr"
+    ],
+    "test": [
+      "simple-linked-list-test.arr"
+    ],
+    "example": [
+      ".meta/example.arr"
+    ]
+  },
+  "blurb": "Write a simple linked list implementation that uses Elements and a List.",
+  "source": "Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists.",
+  "source_url": "https://web.archive.org/web/20160731005714/http://brpreiss.com/books/opus8/html/page96.html"
+}

--- a/exercises/practice/simple-linked-list/.meta/example.arr
+++ b/exercises/practice/simple-linked-list/.meta/example.arr
@@ -1,0 +1,29 @@
+provide-types *
+
+data LinkedList:
+  | empty-list with:
+    method foldl(_, _, acc): acc end,
+  | linked-list(head, tail) with:
+    method foldl(self, f, acc):
+      self.tail.foldl(f, f(self.head, acc))
+    end,
+sharing:
+  method length(self):
+    cases(LinkedList) self:
+      | empty-list => 0
+      | linked-list(_, r) => 
+        r.foldl(lam(elt, acc): acc + 1 end, 1)
+    end
+  end,
+  method push(self, val): linked-list(val, self) end,
+  method reversed(self):
+    self.foldl(
+      lam(elt, acc): linked-list(elt, acc) end,
+      empty-list)
+  end,
+  method to-list(self):
+    self.foldl(
+      lam(elt, acc): acc.push(elt) end,
+      [list: ])
+  end
+end

--- a/exercises/practice/simple-linked-list/.meta/example.arr
+++ b/exercises/practice/simple-linked-list/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 provide-types *
 
 data LinkedList:
@@ -7,6 +9,8 @@ data LinkedList:
     method foldl(self, f, acc):
       self.tail.foldl(f, f(self.head, acc))
     end,
+    method head(self): self.head end,
+    method tail(self): self.tail end
 sharing:
   method length(self):
     cases(LinkedList) self:

--- a/exercises/practice/simple-linked-list/.meta/example.arr
+++ b/exercises/practice/simple-linked-list/.meta/example.arr
@@ -9,8 +9,12 @@ data LinkedList:
     method foldl(self, f, acc):
       self.tail.foldl(f, f(self.head, acc))
     end,
-    method head(self): self.head end,
-    method tail(self): self.tail end
+    method get-head(self):
+      self.head
+    end,
+    method get-tail(self):
+      self.tail
+    end
 sharing:
   method length(self):
     cases(LinkedList) self:

--- a/exercises/practice/simple-linked-list/simple-linked-list-test.arr
+++ b/exercises/practice/simple-linked-list/simple-linked-list-test.arr
@@ -1,112 +1,179 @@
+use context essentials2020
+
 include file("simple-linked-list.arr")
 
 # No canonical data available for this exercise so these have been ported from Python and F#
 
-check "empty list has length zero":
-  empty-list.length() is 0
+#|
+  When working offline, all tests except the first one are skipped by default.
+  Once you get the first test running, unskip the next one until all tests pass locally.
+  Check the block comment below for further details.
+|#
+
+fun empty-list-length-zero():
+  check "empty list has length zero":
+    empty-list.length() is 0
+  end
 end
 
-check "singleton list has length one":
-  linked-list(1, empty-list).length() is 1
+fun singleton-has-length-one():
+  check "singleton list has length one":
+    linked-list(1, empty-list).length() is 1
+  end
 end
 
-check "non-empty list has correct length":
-  result = empty-list
-    ^ linked-list(3, _)
-    ^ linked-list(2, _)
-    ^ linked-list(1, _)
+fun non-empty-list-has-length():
+  check "non-empty list has correct length":
+    result = empty-list
+      ^ linked-list(3, _)
+      ^ linked-list(2, _)
+      ^ linked-list(1, _)
 
-  result.length() is 3
+    result.length() is 3
+  end
 end
 
-check "singleton list has head":
-  linked-list(1, empty-list).head is 1
+fun singleton-has-head():
+  check "singleton list has head":
+    linked-list(1, empty-list).get-head() is 1
+  end
 end
 
-check "non-empty list has correct head":
-  result = empty-list
-    ^ linked-list(1, _)
-    ^ linked-list(2, _)
+fun non-empty-list-has-head():
+  check "non-empty list has correct head":
+    result = empty-list
+      ^ linked-list(1, _)
+      ^ linked-list(2, _)
 
-  result.head is 2
+    result.get-head() is 2
+  end
 end
 
-check "can push to non-empty list":
-  result = empty-list
-    ^ linked-list(3, _)
-    ^ linked-list(2, _)
-    ^ linked-list(1, _)
-  
-  result.push(4).length() is 4
+fun push-to-non-empty-list():
+  check "can push to non-empty list":
+    result = empty-list
+      ^ linked-list(3, _)
+      ^ linked-list(2, _)
+      ^ linked-list(1, _)
+    
+    result.push(4).length() is 4
+  end
 end
 
-check "pushing to empty list changes head":
-  result = empty-list.push(5)
-  
-  result.length() is 1
-  result.head is 5
+fun push-changes-empty-list-head():
+  check "pushing to empty list changes head":
+    result = empty-list.push(5)
+    
+    result.length() is 1
+    result.get-head() is 5
+  end
 end
 
-check "can access second element in list":
-  result = empty-list
-    ^ linked-list(3, _)
-    ^ linked-list(4, _)
-    ^ linked-list(5, _)
+fun access-second-element():
+  check "can access second element in list":
+    result = empty-list
+      ^ linked-list(3, _)
+      ^ linked-list(4, _)
+      ^ linked-list(5, _)
 
-  result.tail.head is 4
+    result.get-tail().get-head() is 4
+  end
 end
 
-check "test singleton list head has no tail":
-  linked-list(1, empty-list).tail is empty-list
+fun singleton-has-no-tail():
+  check "test singleton list head has no tail":
+    linked-list(1, empty-list).get-tail() is empty-list
+  end
 end
 
-check "non-empty list traverse":
-  my-list = range(0, 11).foldl(
-    lam(elt, acc):
-     acc.push(elt)
-    end,
-    empty-list)
-  
-  traversed = range(-10, 0).foldl(
-    lam(n, acc) block:
-      acc.head is num-abs(n)
-      acc.tail
-    end,
-    my-list)
+fun non-empty-list-traverse():
+  check "non-empty list traverse":
+    my-list = range(0, 11).foldl(
+      lam(elt, acc):
+      acc.push(elt)
+      end,
+      empty-list)
+    
+    traversed = range(-10, 0).foldl(
+      lam(n, acc) block:
+        acc.get-head() is num-abs(n)
+        acc.get-tail()
+      end,
+      my-list)
 
-  traversed.tail is empty-list
+    traversed.get-tail() is empty-list
+  end
 end
 
-check "empty linked list to list is empty":
-  empty-list.to-list() is [list: ]
+fun empty-linked-list-is-empty-list():
+  check "empty linked list to list is empty":
+    empty-list.to-list() is [list: ]
+  end
 end
 
-check "singleton linked list to list with single element":
-  linked-list(1, empty-list).to-list() is [list: 1]
+fun singleton-is-list-with-single-element():
+  check "singleton linked list to list with single element":
+    linked-list(1, empty-list).to-list() is [list: 1]
+  end
 end
 
-check "non-empty linked list to list is list with all elements":
-  result = empty-list
-    ^ linked-list(3, _)
-    ^ linked-list(2, _)
-    ^ linked-list(1, _)
+fun non-empty-list-is-list-with-all-elements():
+  check "non-empty linked list to list is list with all elements":
+    result = empty-list
+      ^ linked-list(3, _)
+      ^ linked-list(2, _)
+      ^ linked-list(1, _)
 
-    result.to-list() is [list: 3, 2, 1]
+      result.to-list() is [list: 3, 2, 1]
+  end
 end
 
-check "reversed empty list is empty list":
-  empty-list.reversed().to-list() is [list: ]
+fun reversed-empty-list-is-empty-list():
+  check "reversed empty list is empty list":
+    empty-list.reversed().to-list() is [list: ]
+  end
 end
 
-check "reversed singleton list is same list":
-  linked-list(1, empty-list).reversed() is linked-list(1, empty-list)
+fun reversed-singleton-list-is-same-list():
+  check "reversed singleton list is same list":
+    linked-list(1, empty-list).reversed() is linked-list(1, empty-list)
+  end
 end
 
-check "reverse non-empty list":
-  result = empty-list
-    ^ linked-list(3, _)
-    ^ linked-list(2, _)
-    ^ linked-list(1, _)
+fun reverse-non-empty-list():
+  check "reverse non-empty list":
+    result = empty-list
+      ^ linked-list(3, _)
+      ^ linked-list(2, _)
+      ^ linked-list(1, _)
 
-  result.reversed().to-list() is [list: 1, 2, 3]
+    result.reversed().to-list() is [list: 1, 2, 3]
+  end
 end
+
+#|
+  Code to run each test. Each line corresponds to a test above and whether it should be run.
+  To mark a test to be run, replace `false` with `true` on that same line after the comma.
+  test(test-a, true) will be run. test(test-a, false) will be skipped.
+|#
+
+data TestRun: test(run, active) end
+
+[list: 
+  test(empty-list-length-zero, true),
+  test(singleton-has-length-one, false),
+  test(non-empty-list-has-length, false),
+  test(singleton-has-head, false),
+  test(non-empty-list-has-head, false),
+  test(push-to-non-empty-list, false),
+  test(push-changes-empty-list-head, false),
+  test(access-second-element, false),
+  test(singleton-has-no-tail, false),
+  test(non-empty-list-traverse, false),
+  test(empty-linked-list-is-empty-list, false),
+  test(singleton-is-list-with-single-element, false),
+  test(non-empty-list-is-list-with-all-elements, false),
+  test(reversed-empty-list-is-empty-list, false),
+  test(reversed-singleton-list-is-same-list, false),
+  test(reverse-non-empty-list, false)
+].each(lam(t): when t.active: t.run() end end)

--- a/exercises/practice/simple-linked-list/simple-linked-list-test.arr
+++ b/exercises/practice/simple-linked-list/simple-linked-list-test.arr
@@ -1,0 +1,112 @@
+include file("simple-linked-list.arr")
+
+# No canonical data available for this exercise so these have been ported from Python and F#
+
+check "empty list has length zero":
+  empty-list.length() is 0
+end
+
+check "singleton list has length one":
+  linked-list(1, empty-list).length() is 1
+end
+
+check "non-empty list has correct length":
+  result = empty-list
+    ^ linked-list(3, _)
+    ^ linked-list(2, _)
+    ^ linked-list(1, _)
+
+  result.length() is 3
+end
+
+check "singleton list has head":
+  linked-list(1, empty-list).head is 1
+end
+
+check "non-empty list has correct head":
+  result = empty-list
+    ^ linked-list(1, _)
+    ^ linked-list(2, _)
+
+  result.head is 2
+end
+
+check "can push to non-empty list":
+  result = empty-list
+    ^ linked-list(3, _)
+    ^ linked-list(2, _)
+    ^ linked-list(1, _)
+  
+  result.push(4).length() is 4
+end
+
+check "pushing to empty list changes head":
+  result = empty-list.push(5)
+  
+  result.length() is 1
+  result.head is 5
+end
+
+check "can access second element in list":
+  result = empty-list
+    ^ linked-list(3, _)
+    ^ linked-list(4, _)
+    ^ linked-list(5, _)
+
+  result.tail.head is 4
+end
+
+check "test singleton list head has no tail":
+  linked-list(1, empty-list).tail is empty-list
+end
+
+check "non-empty list traverse":
+  my-list = range(0, 11).foldl(
+    lam(elt, acc):
+     acc.push(elt)
+    end,
+    empty-list)
+  
+  traversed = range(-10, 0).foldl(
+    lam(n, acc) block:
+      acc.head is num-abs(n)
+      acc.tail
+    end,
+    my-list)
+
+  traversed.tail is empty-list
+end
+
+check "empty linked list to list is empty":
+  empty-list.to-list() is [list: ]
+end
+
+check "singleton linked list to list with single element":
+  linked-list(1, empty-list).to-list() is [list: 1]
+end
+
+check "non-empty linked list to list is list with all elements":
+  result = empty-list
+    ^ linked-list(3, _)
+    ^ linked-list(2, _)
+    ^ linked-list(1, _)
+
+    result.to-list() is [list: 3, 2, 1]
+end
+
+check "reversed empty list is empty list":
+  empty-list.reversed().to-list() is [list: ]
+end
+
+check "reversed singleton list is same list":
+  linked-list(1, empty-list).reversed() is linked-list(1, empty-list)
+end
+
+check "reverse non-empty list":
+  result = empty-list
+    ^ linked-list(3, _)
+    ^ linked-list(2, _)
+    ^ linked-list(1, _)
+
+  result.reversed().to-list() is [list: 1, 2, 3]
+end

--- a/exercises/practice/simple-linked-list/simple-linked-list.arr
+++ b/exercises/practice/simple-linked-list/simple-linked-list.arr
@@ -1,0 +1,22 @@
+provide-types *
+
+#|
+  We have given you a beginning structure to help pass the tests here. 
+|#
+data LinkedList:
+  | empty-list
+  | linked-list(head, tail)
+sharing:
+  method length(self):
+    raise("please implement the length method")
+  end,
+  method push(self, val):
+    raise("please implement the push method")
+  end,
+  method reversed(self):
+    raise("please implement the reversed method")
+  end,
+  method to-list(self):
+    raise("please implement the to-list method")
+  end
+end

--- a/exercises/practice/simple-linked-list/simple-linked-list.arr
+++ b/exercises/practice/simple-linked-list/simple-linked-list.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 provide-types *
 
 #|
@@ -5,7 +7,13 @@ provide-types *
 |#
 data LinkedList:
   | empty-list
-  | linked-list(head, tail)
+  | linked-list(head, tail) with:
+    method get-head(self):
+      raise("please implement the get-head method")
+    end,
+    method get-tail(self):
+      raise("please implement the get-tail method")
+    end
 sharing:
   method length(self):
     raise("please implement the length method")


### PR DESCRIPTION
Likely needs an instructions append because the tests works with dot expressions so students either need to use object expressions or data declarations. The official Tour of Pyret provides a barebones [data declaration for a linked list](https://pyret.org/docs/latest/A_Tour_of_Pyret.html#%28part._data-tour%29) in discussing Lists so I think data declarations would be more idiomatic than using an object expression.