### PR TITLE
Update CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "@exercism/pyret",
       "license": "MIT",
       "dependencies": {
-        "pyret-npm": "^0.0.23"
+        "pyret-npm": "^0.0.25"
       }
     },
     "node_modules/ansi-regex": {
@@ -177,9 +177,9 @@
       }
     },
     "node_modules/pyret-npm": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/pyret-npm/-/pyret-npm-0.0.23.tgz",
-      "integrity": "sha512-d3AZkxuAJxwXCxSHoCvb4gc4JtU/ry61S1nsbPrf701nRdpe2ReVAiaEYYRrad3UI6w50Tf3PLogtvKvOVQRiw==",
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/pyret-npm/-/pyret-npm-0.0.25.tgz",
+      "integrity": "sha512-xOQ6s/pnXxkMwt+sxasu/eL29fzpSfGkV+yDn6pWv4CcIA0TIPOIxtATJNSit6EvIo8xlcC683lsl2Guv5ElDA==",
       "dependencies": {
         "command-line-args": "^5.0.2",
         "command-line-usage": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "url": "https://github.com/exercism/pyret"
   },
   "dependencies": {
-    "pyret-npm": "~0.0.23"
+    "pyret-npm": "^0.0.25"
   }
 }


### PR DESCRIPTION
Partially solves #75. The Pyret team updated pyret-npm to 0.0.25, resolving a bug where the Pyret server was looking for the essentials2020 context file in the wrong location. That now means we can explicitly set `use context essentials2020` where previously pyret-npm could only implicitly set that context and would crash if we included that line. By adding it, we avoid shadowing issues on CPO which uses essentials2021 by default.