### PR TITLE
Explicitly set essentials2021 context

### DIFF
--- a/exercises/practice/acronym/.meta/example.arr
+++ b/exercises/practice/acronym/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: abbreviate end
 
  fun abbreviate(phrase):

--- a/exercises/practice/acronym/acronym-test.arr
+++ b/exercises/practice/acronym/acronym-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("acronym.arr")
 
 check "basic":

--- a/exercises/practice/acronym/acronym.arr
+++ b/exercises/practice/acronym/acronym.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: abbreviate end
 
 fun abbreviate(phrase):

--- a/exercises/practice/anagram/.meta/example.arr
+++ b/exercises/practice/anagram/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: find-anagrams end
 
 fun find-anagrams(phrase, candidates):

--- a/exercises/practice/anagram/anagram-test.arr
+++ b/exercises/practice/anagram/anagram-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("anagram.arr")
 
 check "no matches":

--- a/exercises/practice/anagram/anagram.arr
+++ b/exercises/practice/anagram/anagram.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: find-anagrams end
 
 fun find-anagrams(phrase, candidates):

--- a/exercises/practice/armstrong-numbers/.meta/example.arr
+++ b/exercises/practice/armstrong-numbers/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: is-armstrong-number end
 
 import lists as L

--- a/exercises/practice/armstrong-numbers/armstrong-numbers-test.arr
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("armstrong-numbers.arr")
 
 check "Zero is an Armstrong number":

--- a/exercises/practice/armstrong-numbers/armstrong-numbers.arr
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: is-armstrong-number end
 
 fun is-armstrong-number(number):

--- a/exercises/practice/atbash-cipher/.meta/example.arr
+++ b/exercises/practice/atbash-cipher/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: encode, decode end
 
 include string-dict

--- a/exercises/practice/atbash-cipher/atbash-cipher-test.arr
+++ b/exercises/practice/atbash-cipher/atbash-cipher-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("atbash-cipher.arr")
 
 check "encode -> encode yes":

--- a/exercises/practice/atbash-cipher/atbash-cipher.arr
+++ b/exercises/practice/atbash-cipher/atbash-cipher.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: encode, decode end
 
 fun encode(phrase):

--- a/exercises/practice/binary-search/.meta/example.arr
+++ b/exercises/practice/binary-search/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: binary-search end
 
 fun binary-search(numbers, x):

--- a/exercises/practice/binary-search/binary-search-test.arr
+++ b/exercises/practice/binary-search/binary-search-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("binary-search.arr")
 
 check "finds a value in an array with one element":

--- a/exercises/practice/binary-search/binary-search.arr
+++ b/exercises/practice/binary-search/binary-search.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: binary-search end
 
 fun binary-search(lst, elt):

--- a/exercises/practice/bob/.meta/example.arr
+++ b/exercises/practice/bob/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: response end
 
 import lists as L

--- a/exercises/practice/bob/bob-test.arr
+++ b/exercises/practice/bob/bob-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("bob.arr")
 
 check "stating something":

--- a/exercises/practice/bob/bob.arr
+++ b/exercises/practice/bob/bob.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: response end
 
 fun response(hey-bob):

--- a/exercises/practice/collatz-conjecture/.meta/example.arr
+++ b/exercises/practice/collatz-conjecture/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: steps end
 
 fun steps(n):

--- a/exercises/practice/collatz-conjecture/collatz-conjecture-test.arr
+++ b/exercises/practice/collatz-conjecture/collatz-conjecture-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("collatz-conjecture.arr")
 
 check "zero steps for one":

--- a/exercises/practice/collatz-conjecture/collatz-conjecture.arr
+++ b/exercises/practice/collatz-conjecture/collatz-conjecture.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: steps end
 
 fun steps(n):

--- a/exercises/practice/darts/.meta/example.arr
+++ b/exercises/practice/darts/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: score end
 
 fun score(x, y):

--- a/exercises/practice/darts/darts-test.arr
+++ b/exercises/practice/darts/darts-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("darts.arr")
 
 check "Missed target":

--- a/exercises/practice/darts/darts.arr
+++ b/exercises/practice/darts/darts.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: score end
 
 fun score(x, y):

--- a/exercises/practice/difference-of-squares/.meta/example.arr
+++ b/exercises/practice/difference-of-squares/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: square-of-sum, sum-of-squares, difference-of-squares end
 
 fun square-of-sum(number):

--- a/exercises/practice/difference-of-squares/difference-of-squares-test.arr
+++ b/exercises/practice/difference-of-squares/difference-of-squares-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("difference-of-squares.arr")
 
 check "Square the sum of the numbers up to the given number -> square of sum 1":

--- a/exercises/practice/difference-of-squares/difference-of-squares.arr
+++ b/exercises/practice/difference-of-squares/difference-of-squares.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: square-of-sum, sum-of-squares, difference-of-squares end
 
 fun square-of-sum(number):

--- a/exercises/practice/dnd-character/.meta/example.arr
+++ b/exercises/practice/dnd-character/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: character, modifier, ability end
 
 modifier = lam(value): num-floor((value - 10) / 2) end

--- a/exercises/practice/dnd-character/dnd-character-test.arr
+++ b/exercises/practice/dnd-character/dnd-character-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("dnd-character.arr")
 
 check "ability modifier -> ability modifier for score 3 is -4":

--- a/exercises/practice/dnd-character/dnd-character.arr
+++ b/exercises/practice/dnd-character/dnd-character.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: character, modifier, ability end
 
 # Implement the character, modifier, and ability functions

--- a/exercises/practice/etl/.meta/example.arr
+++ b/exercises/practice/etl/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: my-translate end
 
 include string-dict

--- a/exercises/practice/etl/.meta/example.arr
+++ b/exercises/practice/etl/.meta/example.arr
@@ -1,10 +1,10 @@
 use context essentials2020 # Don't delete this line when using Pyret on Exercism 
 
-provide: my-translate end
+provide: translate end
 
 include string-dict
 
-fun my-translate(legacy):
+fun translate(legacy):
   result = block:
     var result = [mutable-string-dict:]
     (legacy.keys().to-list()).each(lam(n): legacy.get-value(n).each(lam(letter): result.set-now(string-to-lower(letter), n) end) end)

--- a/exercises/practice/etl/etl-test.arr
+++ b/exercises/practice/etl/etl-test.arr
@@ -1,19 +1,21 @@
+use context essentials2020
+
 include file("etl.arr")
 
 include string-dict
 
 check "single letter":
-  my-translate([string-dict: "1", [list: "A"]]) is [string-dict: "a", "1"]
+  translate([string-dict: "1", [list: "A"]]) is [string-dict: "a", "1"]
 end
 
 check "single score with multiple letters":
-  my-translate([string-dict: "1", [list: "A", "E", "I", "O", "U"]]) is [string-dict: "a", "1", "e", "1", "i", "1", "o", "1", "u", "1"]
+  translate([string-dict: "1", [list: "A", "E", "I", "O", "U"]]) is [string-dict: "a", "1", "e", "1", "i", "1", "o", "1", "u", "1"]
 end
 
 check "multiple scores with multiple letters":
   input = [string-dict: "1", [list: "A", "E", "I", "O", "U"], "2", [list: "D", "G"]]
   expected = [string-dict: "a", "1", "e", "1", "i", "1", "o", "1", "u", "1", "d", "2", "g", "2"]
-  my-translate(input) is expected
+  translate(input) is expected
 end
 
 check "multiple scores with multiple letters and multiple scores":
@@ -31,5 +33,5 @@ check "multiple scores with multiple letters and multiple scores":
                                   "k", "5", 
                                   "j", "8", "x", "8", 
                                   "q", "10", "z", "10"]
-  my-translate(input) is expected
+  translate(input) is expected
 end

--- a/exercises/practice/etl/etl.arr
+++ b/exercises/practice/etl/etl.arr
@@ -1,5 +1,7 @@
-provide: my-translate end
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
 
-fun my-translate(legacy):
+provide: translate end
+
+fun translate(legacy):
   raise("Please implement the translate function")
 end

--- a/exercises/practice/grains/.meta/example.arr
+++ b/exercises/practice/grains/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: on-square, total end
 
 

--- a/exercises/practice/grains/grains-test.arr
+++ b/exercises/practice/grains/grains-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("grains.arr")
 
 check "returns the number of grains on the square -> grains on square 1":

--- a/exercises/practice/grains/grains.arr
+++ b/exercises/practice/grains/grains.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: on-square, total end
 
 fun on-square(n):

--- a/exercises/practice/hamming/.meta/example.arr
+++ b/exercises/practice/hamming/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: distance end
 
 import lists as L

--- a/exercises/practice/hamming/hamming-test.arr
+++ b/exercises/practice/hamming/hamming-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("hamming.arr")
 
 check "empty strands":

--- a/exercises/practice/hamming/hamming.arr
+++ b/exercises/practice/hamming/hamming.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: distance end
 
 fun distance(first-strand, second-strand):

--- a/exercises/practice/hello-world/.meta/example.arr
+++ b/exercises/practice/hello-world/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: hello end
 
 fun hello():

--- a/exercises/practice/hello-world/hello-world-test.arr
+++ b/exercises/practice/hello-world/hello-world-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("hello-world.arr")
 
 check "Say Hi!":

--- a/exercises/practice/hello-world/hello-world.arr
+++ b/exercises/practice/hello-world/hello-world.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: hello end
 
 fun hello():

--- a/exercises/practice/isogram/.meta/example.arr
+++ b/exercises/practice/isogram/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: is-isogram end
 
 import sets as S

--- a/exercises/practice/isogram/isogram-test.arr
+++ b/exercises/practice/isogram/isogram-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("isogram.arr")
 
 check "empty string":

--- a/exercises/practice/isogram/isogram.arr
+++ b/exercises/practice/isogram/isogram.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: is-isogram end
 
 fun is-isogram(phrase):

--- a/exercises/practice/leap/.meta/example.arr
+++ b/exercises/practice/leap/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: leap end
 
 fun leap(year):

--- a/exercises/practice/leap/leap-test.arr
+++ b/exercises/practice/leap/leap-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("leap.arr")
 
 check "year not divisible by 4 in common year":

--- a/exercises/practice/leap/leap.arr
+++ b/exercises/practice/leap/leap.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: leap end
 
 fun leap(year):

--- a/exercises/practice/list-ops/.meta/example.arr
+++ b/exercises/practice/list-ops/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide:
   my-append, 
   my-concatenate,

--- a/exercises/practice/list-ops/list-ops-test.arr
+++ b/exercises/practice/list-ops/list-ops-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("list-ops.arr")
 
 check "append entries to a list and return the new list -> empty lists":

--- a/exercises/practice/list-ops/list-ops.arr
+++ b/exercises/practice/list-ops/list-ops.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide:
   my-append, 
   my-concatenate,

--- a/exercises/practice/luhn/.meta/example.arr
+++ b/exercises/practice/luhn/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: is-valid end
 
 import lists as L

--- a/exercises/practice/luhn/luhn-test.arr
+++ b/exercises/practice/luhn/luhn-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("luhn.arr")
 
 check "single digit strings can not be valid":

--- a/exercises/practice/luhn/luhn.arr
+++ b/exercises/practice/luhn/luhn.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: is-valid end
 
 fun is-valid(card-number):

--- a/exercises/practice/matrix/.meta/example.arr
+++ b/exercises/practice/matrix/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: matrix end
 
 fun matrix(input :: String):

--- a/exercises/practice/matrix/matrix-test.arr
+++ b/exercises/practice/matrix/matrix-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("matrix.arr")
 
 check "extract row from one number matrix":

--- a/exercises/practice/matrix/matrix.arr
+++ b/exercises/practice/matrix/matrix.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: matrix end
 
 fun matrix(input):

--- a/exercises/practice/nucleotide-count/.meta/example.arr
+++ b/exercises/practice/nucleotide-count/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: nucleotide-counts end
 
 include string-dict

--- a/exercises/practice/nucleotide-count/nucleotide-count-test.arr
+++ b/exercises/practice/nucleotide-count/nucleotide-count-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("nucleotide-count.arr")
 
 include string-dict

--- a/exercises/practice/nucleotide-count/nucleotide-count.arr
+++ b/exercises/practice/nucleotide-count/nucleotide-count.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: nucleotide-counts end
 
 fun nucleotide-counts(strand):

--- a/exercises/practice/pangram/.meta/example.arr
+++ b/exercises/practice/pangram/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: is-pangram end
 
 import lists as L

--- a/exercises/practice/pangram/pangram-test.arr
+++ b/exercises/practice/pangram/pangram-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("pangram.arr")
 
 check "empty sentence":

--- a/exercises/practice/pangram/pangram.arr
+++ b/exercises/practice/pangram/pangram.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: is-pangram end
 
 fun is-pangram(phrase):

--- a/exercises/practice/perfect-numbers/.meta/example.arr
+++ b/exercises/practice/perfect-numbers/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: classify end
 
 import lists as L

--- a/exercises/practice/perfect-numbers/perfect-numbers-test.arr
+++ b/exercises/practice/perfect-numbers/perfect-numbers-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("perfect-numbers.arr")
 
 check "Perfect numbers -> Smallest perfect number is classified correctly":

--- a/exercises/practice/perfect-numbers/perfect-numbers.arr
+++ b/exercises/practice/perfect-numbers/perfect-numbers.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: classify end
 
 fun classify(number):

--- a/exercises/practice/phone-number/.meta/example.arr
+++ b/exercises/practice/phone-number/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: clean end
 
 is-alpha = lam(char :: String) -> Boolean:

--- a/exercises/practice/phone-number/phone-number-test.arr
+++ b/exercises/practice/phone-number/phone-number-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("phone-number.arr")
 
 check "cleans the number":

--- a/exercises/practice/phone-number/phone-number.arr
+++ b/exercises/practice/phone-number/phone-number.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: clean end
 
 fun clean(phone-number):

--- a/exercises/practice/protein-translation/.meta/example.arr
+++ b/exercises/practice/protein-translation/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: proteins end
 
 include string-dict

--- a/exercises/practice/protein-translation/protein-translation-test.arr
+++ b/exercises/practice/protein-translation/protein-translation-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("protein-translation.arr")
 
 check "Empty RNA sequence results in no proteins":

--- a/exercises/practice/protein-translation/protein-translation.arr
+++ b/exercises/practice/protein-translation/protein-translation.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: proteins end
 
 fun proteins(strand):

--- a/exercises/practice/raindrops/.meta/example.arr
+++ b/exercises/practice/raindrops/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: convert end
 
 RULES = [list: [list: 3, "Pling"], [list: 5, "Plang"], [list: 7, "Plong"]]

--- a/exercises/practice/raindrops/raindrops-test.arr
+++ b/exercises/practice/raindrops/raindrops-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("raindrops.arr")
 
 check "the sound for 1 is 1":

--- a/exercises/practice/raindrops/raindrops.arr
+++ b/exercises/practice/raindrops/raindrops.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: convert end
 
 fun convert(n):

--- a/exercises/practice/resistor-color-duo/.meta/example.arr
+++ b/exercises/practice/resistor-color-duo/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: color-code end
 
 RESISTOR-COLORS = [list:

--- a/exercises/practice/resistor-color-duo/resistor-color-duo-test.arr
+++ b/exercises/practice/resistor-color-duo/resistor-color-duo-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("resistor-color-duo.arr")
 
 check "Brown and black":

--- a/exercises/practice/resistor-color-duo/resistor-color-duo.arr
+++ b/exercises/practice/resistor-color-duo/resistor-color-duo.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: color-code end
 
 fun color-code(colors):

--- a/exercises/practice/resistor-color-trio/.meta/example.arr
+++ b/exercises/practice/resistor-color-trio/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: label end
 
 RESISTOR-COLORS = [list:

--- a/exercises/practice/resistor-color-trio/resistor-color-trio-test.arr
+++ b/exercises/practice/resistor-color-trio/resistor-color-trio-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("resistor-color-trio.arr")
 
 check "Orange and orange and black":

--- a/exercises/practice/resistor-color-trio/resistor-color-trio.arr
+++ b/exercises/practice/resistor-color-trio/resistor-color-trio.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: label end
 
 fun label(colors):

--- a/exercises/practice/resistor-color/.meta/example.arr
+++ b/exercises/practice/resistor-color/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: color-code, colors end
 
 RESISTOR-COLORS = [list:

--- a/exercises/practice/resistor-color/resistor-color-test.arr
+++ b/exercises/practice/resistor-color/resistor-color-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("resistor-color.arr")
 
 check "Color codes -> Black":

--- a/exercises/practice/resistor-color/resistor-color.arr
+++ b/exercises/practice/resistor-color/resistor-color.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: color-code, colors end
 
 fun color-code(color):

--- a/exercises/practice/reverse-string/.meta/example.arr
+++ b/exercises/practice/reverse-string/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: reversed end
 
 fun reversed(input):

--- a/exercises/practice/reverse-string/reverse-string-test.arr
+++ b/exercises/practice/reverse-string/reverse-string-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("reverse-string.arr")
 
 check "an empty string":

--- a/exercises/practice/reverse-string/reverse-string.arr
+++ b/exercises/practice/reverse-string/reverse-string.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: reversed end
 
 fun reversed(text):

--- a/exercises/practice/rna-transcription/.meta/example.arr
+++ b/exercises/practice/rna-transcription/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: to-rna end
 
 include string-dict

--- a/exercises/practice/rna-transcription/rna-transcription-test.arr
+++ b/exercises/practice/rna-transcription/rna-transcription-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("rna-transcription.arr")
 
 check "Empty RNA sequence":

--- a/exercises/practice/rna-transcription/rna-transcription.arr
+++ b/exercises/practice/rna-transcription/rna-transcription.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: to-rna end
 
 fun to-rna(dna):

--- a/exercises/practice/roman-numerals/.meta/example.arr
+++ b/exercises/practice/roman-numerals/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: to-roman end
 
 NUMERALS = [list:

--- a/exercises/practice/roman-numerals/roman-numerals-test.arr
+++ b/exercises/practice/roman-numerals/roman-numerals-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("roman-numerals.arr")
 
 check "1 is I":

--- a/exercises/practice/roman-numerals/roman-numerals.arr
+++ b/exercises/practice/roman-numerals/roman-numerals.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: to-roman end
 
 fun to-roman(number):

--- a/exercises/practice/scrabble-score/.meta/example.arr
+++ b/exercises/practice/scrabble-score/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: score end
 
 include string-dict

--- a/exercises/practice/scrabble-score/scrabble-score-test.arr
+++ b/exercises/practice/scrabble-score/scrabble-score-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("scrabble-score.arr")
 
 check "lowercase letter":

--- a/exercises/practice/scrabble-score/scrabble-score.arr
+++ b/exercises/practice/scrabble-score/scrabble-score.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: score end
 
 fun score(word):

--- a/exercises/practice/secret-handshake/.meta/example.arr
+++ b/exercises/practice/secret-handshake/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: commands end
 
 import lists as L

--- a/exercises/practice/secret-handshake/secret-handshake-test.arr
+++ b/exercises/practice/secret-handshake/secret-handshake-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("secret-handshake.arr")
 
 check "wink for 1":

--- a/exercises/practice/secret-handshake/secret-handshake.arr
+++ b/exercises/practice/secret-handshake/secret-handshake.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: commands end
 
 fun commands(binary):

--- a/exercises/practice/series/.meta/example.arr
+++ b/exercises/practice/series/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: slices end
 
 fun slices(series, len):

--- a/exercises/practice/series/series-test.arr
+++ b/exercises/practice/series/series-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("series.arr")
 
 check "slices of one from one":

--- a/exercises/practice/series/series.arr
+++ b/exercises/practice/series/series.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: slices end
 
 fun slices(series, len):

--- a/exercises/practice/space-age/.meta/example.arr
+++ b/exercises/practice/space-age/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: on-planet end
 
 include string-dict

--- a/exercises/practice/space-age/space-age-test.arr
+++ b/exercises/practice/space-age/space-age-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("space-age.arr")
 
 fun around(delta):

--- a/exercises/practice/space-age/space-age.arr
+++ b/exercises/practice/space-age/space-age.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: on-planet end
 
 fun on-planet(planet, seconds):

--- a/exercises/practice/square-root/.meta/example.arr
+++ b/exercises/practice/square-root/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: square-root end
 
 fun square-root(number):

--- a/exercises/practice/square-root/square-root-test.arr
+++ b/exercises/practice/square-root/square-root-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("square-root.arr")
 
 check "root of 1":

--- a/exercises/practice/square-root/square-root.arr
+++ b/exercises/practice/square-root/square-root.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: square-root end
 
 fun square-root(number):

--- a/exercises/practice/strain/.meta/example.arr
+++ b/exercises/practice/strain/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: keep, discard end
 
 fun keep(sequence, predicate):

--- a/exercises/practice/strain/strain-test.arr
+++ b/exercises/practice/strain/strain-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("strain.arr")
 
 check "keep on empty list returns empty list":

--- a/exercises/practice/strain/strain.arr
+++ b/exercises/practice/strain/strain.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: keep, discard end
 
 fun keep(sequence, predicate):

--- a/exercises/practice/triangle/.meta/example.arr
+++ b/exercises/practice/triangle/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: equilateral, isosceles, scalene end
 
 import lists as L

--- a/exercises/practice/triangle/triangle-test.arr
+++ b/exercises/practice/triangle/triangle-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("triangle.arr")
 
 check "equilateral triangle -> all sides are equal":

--- a/exercises/practice/triangle/triangle.arr
+++ b/exercises/practice/triangle/triangle.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: equilateral, isosceles, scalene end
 
 fun equilateral(sides):

--- a/exercises/practice/two-fer/.meta/example.arr
+++ b/exercises/practice/two-fer/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: two-fer end
 
 fun two-fer(name):

--- a/exercises/practice/two-fer/two-fer-test.arr
+++ b/exercises/practice/two-fer/two-fer-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("two-fer.arr")
 
 check "no name given":

--- a/exercises/practice/two-fer/two-fer.arr
+++ b/exercises/practice/two-fer/two-fer.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: two-fer end
 
 fun two-fer(name):

--- a/exercises/practice/word-count/.meta/example.arr
+++ b/exercises/practice/word-count/.meta/example.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: word-count end
 
 include string-dict

--- a/exercises/practice/word-count/word-count-test.arr
+++ b/exercises/practice/word-count/word-count-test.arr
@@ -1,3 +1,5 @@
+use context essentials2020
+
 include file("word-count.arr")
 
 include string-dict

--- a/exercises/practice/word-count/word-count.arr
+++ b/exercises/practice/word-count/word-count.arr
@@ -1,3 +1,5 @@
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
+
 provide: word-count end
 
 fun word-count(phrase):


### PR DESCRIPTION
Fixes the underlying issue in #75.

pyret-npm imports names from the essentials2020 module implicitly if we don't explicitly do it. CPO can toggle between essentials2020 or essentials2021, but pyret-npm only has essentials2020. By explicitly setting the module, it's clear to students what names already exist in the namespace, avoiding compilation issues. If students decide to work in CPO, this will be a good reminder to toggle CPO itself to essentials2020.