### PR TITLE
Fix missing warnings about changing essentials2020

### DIFF
--- a/exercises/practice/bank-account/.meta/example.arr
+++ b/exercises/practice/bank-account/.meta/example.arr
@@ -1,4 +1,4 @@
-use context essentials2020
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
 
 provide-types *
 

--- a/exercises/practice/bank-account/bank-account.arr
+++ b/exercises/practice/bank-account/bank-account.arr
@@ -1,4 +1,4 @@
-use context essentials2020
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
 
 provide-types *
 

--- a/exercises/practice/clock/.meta/example.arr
+++ b/exercises/practice/clock/.meta/example.arr
@@ -1,4 +1,4 @@
-use context essentials2020
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
 
 provide-types *
 

--- a/exercises/practice/clock/clock.arr
+++ b/exercises/practice/clock/clock.arr
@@ -1,4 +1,4 @@
-use context essentials2020
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
 
 provide-types *
 

--- a/exercises/practice/eliuds-eggs/.meta/example.arr
+++ b/exercises/practice/eliuds-eggs/.meta/example.arr
@@ -1,4 +1,4 @@
-use context essentials2020
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
 
 provide: egg-count end
 

--- a/exercises/practice/flatten-array/.meta/example.arr
+++ b/exercises/practice/flatten-array/.meta/example.arr
@@ -1,4 +1,4 @@
-use context essentials2020
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
 
 provide: flatten end
 

--- a/exercises/practice/flatten-array/flatten-array.arr
+++ b/exercises/practice/flatten-array/flatten-array.arr
@@ -1,4 +1,4 @@
-use context essentials2020
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
 
 provide: flatten end
 

--- a/exercises/practice/high-scores/high-scores.arr
+++ b/exercises/practice/high-scores/high-scores.arr
@@ -1,4 +1,4 @@
-use context essentials2020
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
 
 provide: high-scores end
 

--- a/exercises/practice/queen-attack/.meta/example.arr
+++ b/exercises/practice/queen-attack/.meta/example.arr
@@ -1,4 +1,4 @@
-use context essentials2020
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
 
 provide-types *
 

--- a/exercises/practice/queen-attack/queen-attack.arr
+++ b/exercises/practice/queen-attack/queen-attack.arr
@@ -1,4 +1,4 @@
-use context essentials2020
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
 
 provide-types *
 

--- a/exercises/practice/robot-simulator/.meta/example.arr
+++ b/exercises/practice/robot-simulator/.meta/example.arr
@@ -1,4 +1,4 @@
-use context essentials2020
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
 
 provide-types *
 

--- a/exercises/practice/simple-linked-list/.meta/example.arr
+++ b/exercises/practice/simple-linked-list/.meta/example.arr
@@ -1,4 +1,4 @@
-use context essentials2020
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
 
 provide-types *
 

--- a/exercises/practice/simple-linked-list/simple-linked-list.arr
+++ b/exercises/practice/simple-linked-list/simple-linked-list.arr
@@ -1,4 +1,4 @@
-use context essentials2020
+use context essentials2020 # Don't delete this line when using Pyret on Exercism 
 
 provide-types *
 


### PR DESCRIPTION
When building the track, I missed a few spots where I didn't warn the student to remove the use context line.