### PR TITLE
Create run-configlet-sync.yml

### DIFF
--- a/.github/workflows/run-configlet-sync.yml
+++ b/.github/workflows/run-configlet-sync.yml
@@ -1,0 +1,10 @@
+name: Run Configlet Sync
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 15 * *'
+
+jobs:
+  call-gha-workflow:
+    uses: exercism/github-actions/.github/workflows/configlet-sync.yml@main


### PR DESCRIPTION
Currently, the workflow is configured to run on the **15th of every month** via cron.

Let me know if you'd prefer a different schedule or trigger (e.g., weekly, 1st of each month, etc.)!