### PR TITLE
Change highlightjs language

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,7 +13,7 @@
   "online_editor": {
     "indent_style": "space",
     "indent_size": 2,
-    "highlightjs_language": "plaintext"
+    "highlightjs_language": "pyret"
   },
   "test_runner": {
     "average_run_time": 3


### PR DESCRIPTION
Related to #261, we have a highlightjs plugin at https://github.com/exercism/highlightjs-pyret that can be used for this track once it gets published. By switching over now, the track should seamlessly switch over once the npm package is published.