### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/bank-account/.docs/instructions.append.md
+++ b/exercises/practice/bank-account/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 Pyret doesn't support concurrency so that requirement can be set aside. Account operations are sequential on a single thread.

--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 The tests for this exercise expect that your clock will be implemented using a `data declaration` in Pyret.
 If you are unfamiliar with data declarations, [the official documentation][data-declaration] is a good place to start.
 

--- a/exercises/practice/flatten-array/.docs/instructions.append.md
+++ b/exercises/practice/flatten-array/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 This exercise is implemented using the built-in [List] datatype, not RawArrays.
 
 [list]: https://pyret.org/docs/latest/lists.html

--- a/exercises/practice/high-scores/.docs/instructions.append.md
+++ b/exercises/practice/high-scores/.docs/instructions.append.md
@@ -1,6 +1,11 @@
 # Instructions append
 
-Many of our lower-level Pyret exercises are solveable with only [function application expressions] in the form of `foo(1)` . This exercise however expects that [dot expressions] can be used to access data and method fields on what your function returns. This can be done with [object expressions], allowing you to access the fields of an object literal. [Data declarations] are a similar but more advanced approach that utilizes data and method fields as well.
+## Implementation
+
+Many of our lower-level Pyret exercises are solveable with only [function application expressions] in the form of `foo(1)` .
+This exercise however expects that [dot expressions] can be used to access data and method fields on what your function returns.
+This can be done with [object expressions], allowing you to access the fields of an object literal.
+[Data declarations] are a similar but more advanced approach that utilizes data and method fields as well.
 
 [function application expressions]: https://pyret.org/docs/latest/Expressions.html#%28part._s~3aapp-expr%29
 [dot expressions]: https://pyret.org/docs/latest/Expressions.html#%28part._s~3adot-expr%29


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.